### PR TITLE
collision and triggers update

### DIFF
--- a/assets/prefabs/arrow.prefab
+++ b/assets/prefabs/arrow.prefab
@@ -4,9 +4,8 @@
 	"Gravity" : {},
 	"Arrow" : {},
 	"BoxShape" : {
-		"extents" : [1, 1, 2]
+		"extents" : [0.5, 0.5, 1]
 	},
-	"Trigger" : {},
 	"Stick" : {},
 	"Mesh" : {
         "mesh" : "CombatSystem:spear",

--- a/assets/prefabs/arrow.prefab
+++ b/assets/prefabs/arrow.prefab
@@ -3,6 +3,11 @@
 	"Mass" : {},
 	"Gravity" : {},
 	"Arrow" : {},
+	"BoxShape" : {
+		"extents" : [1, 1, 2]
+	},
+	"Trigger" : {},
+	"Stick" : {},
 	"Mesh" : {
         "mesh" : "CombatSystem:spear",
         "material" : "CombatSystem:tool"

--- a/src/main/java/org/terasology/combatSystem/physics/events/CombatForceEvent.java
+++ b/src/main/java/org/terasology/combatSystem/physics/events/CombatForceEvent.java
@@ -1,9 +1,9 @@
 package org.terasology.combatSystem.physics.events;
 
-import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.event.Event;
 import org.terasology.math.geom.Vector3f;
 
-public class CombatForceEvent implements Component{
+public class CombatForceEvent implements Event{
     Vector3f force;
     
     public CombatForceEvent(Vector3f force){

--- a/src/main/java/org/terasology/combatSystem/weaponFeatures/components/StickComponent.java
+++ b/src/main/java/org/terasology/combatSystem/weaponFeatures/components/StickComponent.java
@@ -2,6 +2,6 @@ package org.terasology.combatSystem.weaponFeatures.components;
 
 import org.terasology.entitySystem.Component;
 
-public class FixedLocationComponent implements Component{
+public class StickComponent implements Component{
 
 }

--- a/src/main/java/org/terasology/combatSystem/weaponFeatures/systems/CollisionHandlingSystem.java
+++ b/src/main/java/org/terasology/combatSystem/weaponFeatures/systems/CollisionHandlingSystem.java
@@ -21,14 +21,18 @@ public class CollisionHandlingSystem extends BaseComponentSystem{
         LocationComponent otherEntityLocation = otherEntity.getComponent(LocationComponent.class);
         if(location != null && otherEntityLocation != null){
             Vector3f finalLoc = event.getOtherEntityContactPoint();
-            finalLoc.add(otherEntityLocation.getWorldPosition());
             location.setWorldPosition(finalLoc);
             
+            MassComponent body = entity.getComponent(MassComponent.class);
+            body.acceleration.set(0, 0, 0);
+            body.velocity.set(0, 0, 0);
+            body.force.set(0, 0, 0);
+            
+            entity.saveComponent(body);
             entity.saveComponent(location);
         }
         
         entity.removeComponent(GravityComponent.class);
-        
         
     }
 

--- a/src/main/java/org/terasology/combatSystem/weaponFeatures/systems/CollisionHandlingSystem.java
+++ b/src/main/java/org/terasology/combatSystem/weaponFeatures/systems/CollisionHandlingSystem.java
@@ -1,0 +1,35 @@
+package org.terasology.combatSystem.weaponFeatures.systems;
+
+import org.terasology.combatSystem.physics.components.GravityComponent;
+import org.terasology.combatSystem.physics.components.MassComponent;
+import org.terasology.combatSystem.weaponFeatures.components.StickComponent;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.events.CollideEvent;
+
+@RegisterSystem
+public class CollisionHandlingSystem extends BaseComponentSystem{
+    
+    @ReceiveEvent(components = {StickComponent.class})
+    public void sticking(CollideEvent event, EntityRef entity){
+        EntityRef otherEntity = event.getOtherEntity();
+        LocationComponent location = entity.getComponent(LocationComponent.class);
+        LocationComponent otherEntityLocation = otherEntity.getComponent(LocationComponent.class);
+        if(location != null && otherEntityLocation != null){
+            Vector3f finalLoc = event.getOtherEntityContactPoint();
+            finalLoc.add(otherEntityLocation.getWorldPosition());
+            location.setWorldPosition(finalLoc);
+            
+            entity.saveComponent(location);
+        }
+        
+        entity.removeComponent(GravityComponent.class);
+        
+        
+    }
+
+}

--- a/src/main/java/org/terasology/combatSystem/weaponFeatures/systems/LaunchEntitySystem.java
+++ b/src/main/java/org/terasology/combatSystem/weaponFeatures/systems/LaunchEntitySystem.java
@@ -1,6 +1,7 @@
 package org.terasology.combatSystem.weaponFeatures.systems;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.terasology.combatSystem.physics.components.MassComponent;
 import org.terasology.combatSystem.physics.events.CombatImpulseEvent;
@@ -15,14 +16,27 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.math.Direction;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.CollisionGroup;
+import org.terasology.physics.HitResult;
+import org.terasology.physics.StandardCollisionGroup;
+import org.terasology.physics.engine.PhysicsEngine;
+import org.terasology.physics.events.CollideEvent;
 import org.terasology.registry.In;
+
+import com.google.common.collect.Lists;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class LaunchEntitySystem extends BaseComponentSystem implements UpdateSubscriberSystem{
     @In
     private EntityManager entityManager;
+    @In
+    private LocalPlayer localPlayer;
+//    @In
+//    private PhysicsEngine physics;
     
     @ReceiveEvent(components = {LaunchEntityComponent.class})
     public void onFire(PrimaryAttackEvent event, EntityRef entity){
@@ -35,7 +49,7 @@ public class LaunchEntitySystem extends BaseComponentSystem implements UpdateSub
                 // sets the location of entity to current player's bow location where it is spawned
                 LocationComponent location = entityToLaunch.getComponent(LocationComponent.class);
                 location.setWorldScale(0.5f);
-                location.setWorldPosition(entity.getComponent(LocationComponent.class).getWorldPosition());
+                location.setWorldPosition(localPlayer.getPosition().addY(0.5f));
                 
                 // rotates the entity to face in the direction of pointer
                 Vector3f initialDir = location.getWorldDirection().invert();
@@ -60,21 +74,33 @@ public class LaunchEntitySystem extends BaseComponentSystem implements UpdateSub
     @Override
     public void update(float delta) {
         // TODO Auto-generated method stub
-//        Iterable<EntityRef> entitiesWith = entityManager.getEntitiesWith(ArrowComponent.class);
-//        Iterator<EntityRef> entities = entitiesWith.iterator();
-//        while(entities.hasNext()){
-//            EntityRef arrow = entities.next();
-//            MassComponent body = arrow.getComponent(MassComponent.class);
-//            LocationComponent location = arrow.getComponent(LocationComponent.class);
-//            
-//            Vector3f finalDir = new Vector3f(body.velocity);
-//            if(finalDir.length() != 0.0f){
-//                Vector3f initialDir = location.getWorldDirection().invert();
-//                finalDir.normalize();
-//                location.setWorldRotation(Quat4f.shortestArcQuat(initialDir, finalDir));
-//            }
-//            
-//            arrow.saveComponent(location);
-//        }
+        Iterable<EntityRef> entitiesWith = entityManager.getEntitiesWith(ArrowComponent.class);
+        Iterator<EntityRef> entities = entitiesWith.iterator();
+        while(entities.hasNext()){
+            EntityRef arrow = entities.next();
+            MassComponent body = arrow.getComponent(MassComponent.class);
+            LocationComponent location = arrow.getComponent(LocationComponent.class);
+            
+            // change rotation of arrow to always be tangent to path of trajectory
+            if(body != null && location != null){
+                Vector3f finalDir = new Vector3f(body.velocity);
+                if(finalDir.length() != 0.0f){
+                    Vector3f initialDir = Direction.FORWARD.getVector3f().invert();
+                    finalDir.normalize();
+                    location.setWorldRotation(Quat4f.shortestArcQuat(initialDir, finalDir));
+                }
+                
+                // raytrace the next step for collisions
+//                HitResult rayTraceResult;
+//                float displacement = body.velocity.length()*(1.0f/60.0f);
+//                CollisionGroup filter = StandardCollisionGroup.DEFAULT;
+//                rayTraceResult = physics.rayTrace(location.getWorldPosition(), finalDir, displacement, filter);
+//                if(rayTraceResult.isHit()){
+//                    arrow.send(new CollideEvent(rayTraceResult.getEntity(), Vector3f.north(), rayTraceResult.getHitPoint(), 0.0f, rayTraceResult.getHitNormal()));
+//                }
+            }
+            
+            arrow.saveComponent(location);
+        }
     }
 }

--- a/src/main/java/org/terasology/combatSystem/world/NPCSpawnSystem.java
+++ b/src/main/java/org/terasology/combatSystem/world/NPCSpawnSystem.java
@@ -6,11 +6,9 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.utilities.Assets;
-import org.terasology.world.RelevanceRegionComponent;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class NPCSpawnSystem extends BaseComponentSystem{

--- a/src/main/java/org/terasology/combatSystem/world/NPCSpawnSystem.java
+++ b/src/main/java/org/terasology/combatSystem/world/NPCSpawnSystem.java
@@ -7,8 +7,15 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.physics.CollisionGroup;
+import org.terasology.physics.StandardCollisionGroup;
+import org.terasology.physics.components.RigidBodyComponent;
+import org.terasology.physics.shapes.BoxShapeComponent;
 import org.terasology.registry.In;
+import org.terasology.rendering.logic.SkeletalMeshComponent;
 import org.terasology.utilities.Assets;
+
+import com.google.common.collect.Lists;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class NPCSpawnSystem extends BaseComponentSystem{
@@ -27,7 +34,17 @@ public class NPCSpawnSystem extends BaseComponentSystem{
     
     @Override
     public void postBegin() {
-        npc1 = entityManager.create(staticCharacterPrefab, new Vector3f(0,2.5f,0));
+        npc1 = entityManager.create(staticCharacterPrefab, new Vector3f(0,2.5f,5));
+        
+        BoxShapeComponent boxShape = new BoxShapeComponent();
+        SkeletalMeshComponent skeletalMesh = npc1.getComponent(SkeletalMeshComponent.class);
+        boxShape.extents = skeletalMesh.mesh.getStaticAabb().getExtents().scale(2.0f);
+        
+        RigidBodyComponent rigidBody = npc1.getComponent(RigidBodyComponent.class);
+        rigidBody.collidesWith = Lists.<CollisionGroup>newArrayList(StandardCollisionGroup.ALL);
+        
+        npc1.addOrSaveComponent(boxShape);
+        npc1.saveComponent(rigidBody);
     }
 
 }


### PR DESCRIPTION
The arrows which have trigger component only react with objects that have a GhostCollider attached. For eg. character collider in case of character and PairCachingGhostObject in case of other arrows with triggers. They do not react to collisions with entities that have RigidBody because they use different collider namely RigidBody