### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/combatSystem/physics/components/FrictionComponent.java
+++ b/src/main/java/org/terasology/combatSystem/physics/components/FrictionComponent.java
@@ -15,10 +15,10 @@ import org.terasology.gestalt.entitysystem.component.Component;
  */
 public class FrictionComponent implements Component<FrictionComponent> {
     @Replicate
-    float friction = 20.0f;
+    public float friction = 20.0f;
 
     @Replicate
-    float velocity = 20.0f;
+    public float velocity = 20.0f;
 
     @Override
     public void copyFrom(FrictionComponent other) {

--- a/src/main/java/org/terasology/combatSystem/weaponFeatures/components/StickComponent.java
+++ b/src/main/java/org/terasology/combatSystem/weaponFeatures/components/StickComponent.java
@@ -17,7 +17,7 @@ public class StickComponent implements Component<StickComponent> {
     public float pierceAmount = 1.0f;
 
     @Replicate
-    EntityRef target = EntityRef.NULL;
+    public EntityRef target = EntityRef.NULL;
 
     public void setTarget(EntityRef entity) {
         target = entity;


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191